### PR TITLE
Allow encoding/decoding without secret, and with algorith as 'none'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "jwt-scala"
 
-version := "1.0"
+version := "1.1"
 
 organization := "io.really"
 

--- a/src/main/scala/io/really/jwt/JWT.scala
+++ b/src/main/scala/io/really/jwt/JWT.scala
@@ -106,6 +106,19 @@ object JWT {
   }
 
   /**
+   * encode jwt with no verifying secret
+   * @param payload that represent data for token
+   * @param header that represent data for JWT header
+   * @param algorithm that represent algorithm using on JWT
+   * @return String
+   */
+  def encodeWithoutSecret(payload: JsObject, header: JsObject = Json.obj(), algorithm: Option[Algorithm] = Some(Algorithm.HS256)): String = {
+    val headerEncoded = encodeHeader(algorithm, header)
+    val payloadEncoded = encodePayload(payload)
+    s"${headerEncoded}.${payloadEncoded}."
+  }
+
+  /**
    * split JWT to Header, Payload and signature
    * @param str that represent JWT
    * @param verify if this JWT is contains signature part or not
@@ -129,7 +142,7 @@ object JWT {
         val headerPart :: payloadPart :: signaturePart = parts
         val header = Json.parse(decodeBase64url(headerPart)).as[JsObject]
         val payload = Json.parse(decodeBase64url(payloadPart)).as[JsObject]
-        val signature = signaturePart.head
+        val signature = signaturePart.headOption.getOrElse("")
         val signingInput = s"${headerPart}.${payloadPart}"
         Success((header, payload, signature, signingInput))
       case Failure(e) => Failure(e)

--- a/src/main/scala/io/really/jwt/package.scala
+++ b/src/main/scala/io/really/jwt/package.scala
@@ -38,6 +38,12 @@ package object jwt {
     /**
      * Represent type of RSASSA Algorithm that using SHA-256 hash algorithm
      */
+    case object NONE extends Algorithm {
+      override def toString = "none"
+    }
+    /**
+     * Represent type of RSASSA Algorithm that using SHA-256 hash algorithm
+     */
     case object RS256 extends Algorithm {
       override def toString = "RS256"
     }
@@ -65,6 +71,7 @@ package object jwt {
       case JsString("HmacSHA256") => JsSuccess(HS256)
       case JsString("HmacSHA384") => JsSuccess(HS384)
       case JsString("HmacSHA512") => JsSuccess(HS512)
+      case JsString("none") => JsSuccess(NONE)
       case JsString("RS256") => JsSuccess(RS256)
       case JsString("RS384") => JsSuccess(RS384)
       case JsString("RS512") => JsSuccess(RS512)

--- a/src/test/scala/io/really/jwt/JWTSpec.scala
+++ b/src/test/scala/io/really/jwt/JWTSpec.scala
@@ -16,6 +16,13 @@ class JWTSpec extends FlatSpec with ShouldMatchers {
     assertResult(JWT.decode(jwt, None).asInstanceOf[JWTResult.JWT].payload)(payload)
   }
 
+  it should "generate json web token with no provided secret" in {
+    val payload = Json.obj("name" -> "Ahmed", "email" -> "ahmed@gmail.com")
+    val jwt = JWT.encodeWithoutSecret(payload)
+
+    assertResult(JWT.decode(jwt, None).asInstanceOf[JWTResult.JWT].payload)(payload)
+  }
+
   "decode" should "decode token and verify it" in {
     val payload = Json.obj("name" -> "Ahmed", "email" -> "ahmed@gmail.com")
     val jwt = JWT.encode("secret", payload)
@@ -49,6 +56,26 @@ class JWTSpec extends FlatSpec with ShouldMatchers {
 
   it should "return EmptyJWT if you try decode empty string" in {
     assertResult(JWTResult.EmptyJWT)(JWT.decode("", Some("secret")))
+  }
+
+  it should "decode a token encoded with no secret" in {
+    val payload = Json.obj("name" -> "Ahmed", "email" -> "ahmed@gmail.com")
+    val jwt = JWT.encodeWithoutSecret(payload)
+
+    val token = JWT.decode(jwt, None).asInstanceOf[JWTResult.JWT]
+
+    assertResult(payload)(token.payload)
+    assertResult(Json.obj("alg" -> Algorithm.HS256, "typ" -> "JWT"))(token.header.toJson)
+  }
+
+  it should "decode a token encoded with no algorithm" in {
+    val payload = Json.obj("name" -> "Ahmed", "email" -> "ahmed@gmail.com")
+    val jwt = JWT.encodeWithoutSecret(payload, Json.obj(), Some(Algorithm.NONE))
+
+    val token = JWT.decode(jwt, None).asInstanceOf[JWTResult.JWT]
+
+    assertResult(payload)(token.payload)
+    assertResult(Json.obj("alg" -> Algorithm.NONE, "typ" -> "JWT"))(token.header.toJson)
   }
 
 }


### PR DESCRIPTION
This allows the library to be used when decoding token_id responses from the Windows graph api
