### PR TITLE
Fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Jwt-scala has been published for scala 2.11 and sbt 0.13.6
 
 Add the dependency to your build.sbt
 ```
-libraryDependencies += "io.really" %% "jwt-scala" % "1.2"
+libraryDependencies += "io.really" %% "jwt-scala" % "1.2.1"
 ```
 
 ### Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "jwt-scala"
 
-version := "1.2"
+version := "1.2.1"
 
 organization := "io.really"
 

--- a/src/main/scala/io/really/jwt/package.scala
+++ b/src/main/scala/io/really/jwt/package.scala
@@ -10,7 +10,9 @@ import play.api.libs.json._
  */
 package object jwt {
 
-  sealed trait Algorithm
+  sealed trait Algorithm{
+    def name:String
+  }
 
   /**
    * Algorithm represent type of algorithms that used on JWT
@@ -22,42 +24,49 @@ package object jwt {
      */
     case object HS256 extends Algorithm {
       override def toString = "HmacSHA256"
+      def name = "HS256"
     }
     /**
      * Represent type of HMAC Algorithm that using SHA-384 hash algorithm
      */
     case object HS384 extends Algorithm {
       override def toString = "HmacSHA384"
+      def name = "HS384"
     }
     /**
      * Represent type of HMAC Algorithm that using SHA-512 hash algorithm
      */
     case object HS512 extends Algorithm {
       override def toString = "HmacSHA512"
+      def name = "HS512"
     }
     /**
      * Represent type of RSASSA Algorithm that using SHA-256 hash algorithm
      */
     case object NONE extends Algorithm {
       override def toString = "none"
+      def name = "none"
     }
     /**
      * Represent type of RSASSA Algorithm that using SHA-256 hash algorithm
      */
     case object RS256 extends Algorithm {
       override def toString = "SHA256withRSA"
+      def name = "RS256"
     }
     /**
      * Represent type of RSASSA Algorithm that using SHA-384 hash algorithm
      */
     case object RS384 extends Algorithm {
       override def toString = "SHA384withRSA"
+      def name = "RS384"
     }
     /**
      * Represent type of RSASSA Algorithm that using SHA-512 hash algorithm
      */
     case object RS512 extends Algorithm {
       override def toString = "SHA512withRSA"
+      def name = "RS512"
     }
   }
 
@@ -68,21 +77,29 @@ package object jwt {
     import Algorithm._
 
     def reads(v: JsValue): JsResult[Algorithm] = v match {
+      //HSxxx algorithms
       case JsString("HmacSHA256") => JsSuccess(HS256)
       case JsString("HmacSHA384") => JsSuccess(HS384)
       case JsString("HmacSHA512") => JsSuccess(HS512)
-      case JsString("none") => JsSuccess(NONE)
+        // Alias names
+      case JsString("HS256") => JsSuccess(HS256)
+      case JsString("HS384") => JsSuccess(HS384)
+      case JsString("HS512") => JsSuccess(HS512)
+
+      //RSxxx algorithms
       case JsString("SHA256withRSA") => JsSuccess(RS256)
       case JsString("SHA384withRSA") => JsSuccess(RS384)
       case JsString("SHA512withRSA") => JsSuccess(RS512)
-      // Alias names
+        // Alias names
       case JsString("RS256") => JsSuccess(RS256)
       case JsString("RS384") => JsSuccess(RS384)
       case JsString("RS512") => JsSuccess(RS512)
+
+      case JsString("none") => JsSuccess(NONE)
       case _ => JsError(Seq(JsPath() -> Seq(ValidationError("error.unsupported.algorithm"))))
     }
 
-    def writes(alg: Algorithm): JsValue = JsString(alg.toString)
+    def writes(alg: Algorithm): JsValue = JsString(alg.name)
   }
 
   /**


### PR DESCRIPTION
This is a backward compatible fix :
The newly issued token will follow the header algorithm spec (aka "HS256" and not "HmacSHA256")
But the code will remain backward compatible as the Json.Reads will accept the old and new form