### PR TITLE
Fixed signature verification bypass issue.

### DIFF
--- a/src/main/scala/io/really/jwt/JWT.scala
+++ b/src/main/scala/io/really/jwt/JWT.scala
@@ -192,11 +192,16 @@ object JWT {
    */
   private[jwt] def verifySignature(algorithm: Algorithm, key: String, signingInput: String, signature: String): Boolean = {
     algorithm match {
-      case Algorithm.HS256 | Algorithm.HS384 | Algorithm.HS512 =>
+      case Algorithm.HS256 | Algorithm.HS384 | Algorithm.HS512 => {
+        if(PemUtil.isPublicKey(key)) return false
         encodedSignature(signingInput, key, Some(algorithm)).equals(signature)
+      }
       case Algorithm.RS256 | Algorithm.RS384 | Algorithm.RS512 =>
         verifyRsa(algorithm, key, signingInput, signature)
-      case Algorithm.NONE => true
+      case Algorithm.NONE if key == None  => 
+        true
+      case _ =>
+        false
     }
   }
 

--- a/src/main/scala/io/really/jwt/PemUtil.scala
+++ b/src/main/scala/io/really/jwt/PemUtil.scala
@@ -4,7 +4,7 @@ import java.security.spec.PKCS8EncodedKeySpec
 import java.security.{PrivateKey, PublicKey}
 import io.really.jwt.JWTException.{InvalidPublicKey, InvalidPrivateKey}
 import org.apache.commons.codec.binary.Base64
-import scala.util.Try
+import scala.util.{Try, Success, Failure}
 
 object PemUtil {
 
@@ -22,6 +22,16 @@ object PemUtil {
       DerUtil.decodePrivateKey(bytes)
     }
     trial.getOrElse(throw new InvalidPrivateKey())
+  }
+
+  def isPublicKey(pem: String): Boolean = {
+    Try {
+      val bytes = pemToDer(pem)
+      DerUtil.decodePublicKey(bytes)
+    } match {
+      case Success(v) => true
+      case Failure(e) => false
+    }
   }
 
   def removeBeginEnd(pem: String) = {

--- a/src/test/scala/io/really/jwt/JWTSpec.scala
+++ b/src/test/scala/io/really/jwt/JWTSpec.scala
@@ -5,6 +5,7 @@ package io.really.jwt
 
 import org.scalatest.{ShouldMatchers, FlatSpec}
 import play.api.libs.json.Json
+import org.apache.commons.codec.binary.Base64
 
 
 class JWTSpec extends FlatSpec with ShouldMatchers {
@@ -76,6 +77,16 @@ class JWTSpec extends FlatSpec with ShouldMatchers {
 
     assertResult(payload)(token.payload)
     assertResult(Json.obj("alg" -> Algorithm.NONE, "typ" -> "JWT"))(token.header.toJson)
+  }
+
+  it should "return Invalid Signature if you try decode singed JWT with crafted None algorithm header" in {
+    val payload = Json.obj("name" -> "Test", "email" -> "test@example.com")
+    var jwt=JWT.encode("secret",payload)
+    
+    val none_header="{\"alg\":\"none\", \"typ\":\"JWT\"}"
+    jwt=jwt.replaceAll("^.*?\\.",Base64.encodeBase64URLSafeString(none_header.getBytes("utf-8"))+".");
+    
+    assertResult(JWTResult.InvalidSignature)(JWT.decode(jwt, Some("secret")))
   }
 
 }

--- a/src/test/scala/io/really/jwt/RSASpec.scala
+++ b/src/test/scala/io/really/jwt/RSASpec.scala
@@ -90,4 +90,15 @@ class RSASpec extends FlatSpec with ShouldMatchers {
     assertResult(Json.obj("alg" -> Algorithm.RS256, "typ" -> "JWT"))(token.header.toJson)
   }
 
+  it should "return Invalid Signature if you try decode RSXXX signed JWT with crafted HSXXX algorithm header" in {
+    val payload = Json.obj("name" -> "Test", "email" -> "test@exemple.com")    
+    val publicKeyStr = MyKeyStore.publicKeyStr 
+    val privateKeyStr = MyKeyStore.privateKeyStr
+    val jwt_valid = JWT.encode(privateKeyStr, payload, Json.obj(), Some(Algorithm.RS256))
+    val jwt_invalid = JWT.encode(publicKeyStr, payload, Json.obj(), Some(Algorithm.HS256))
+
+    assertResult(payload)(JWT.decode(jwt_valid, Some(publicKeyStr)).asInstanceOf[JWTResult.JWT].payload)
+    assertResult(JWTResult.InvalidSignature)(JWT.decode(jwt_invalid, Some(publicKeyStr)))
+  }
+
 }


### PR DESCRIPTION
I've fixed these signature verification bypass issues:
- Allows malicious user to bypass all type of verification by using None header
- Allows malicious user to bypass RSXXX verification by using crafted header with HSXXX algorithm.

To maintain compatibility, this fix doesn't require extra parameters but try to check key type when using HSXXX algorithm.